### PR TITLE
Add unit declarator to module and class declarations

### DIFF
--- a/lib/HTML/Template.pm
+++ b/lib/HTML/Template.pm
@@ -1,4 +1,4 @@
-class HTML::Template;
+unit class HTML::Template;
 
 use Text::Escape;
 use HTML::Template::Grammar;

--- a/lib/Text/Escape.pm
+++ b/lib/Text/Escape.pm
@@ -1,5 +1,5 @@
 use v6;
-module Text::Escape;
+unit module Text::Escape;
 
 sub escape($str, $how) is export {
     my $m = $how.lc;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.