### PR TITLE
Remove quotes from character class

### DIFF
--- a/lib/HTML/Template/Grammar.pm
+++ b/lib/HTML/Template/Grammar.pm
@@ -39,7 +39,7 @@ grammar HTML::Template::Grammar {
 
     token tag_start  { '<TMPL_' };
     token attributes { \s+ 'NAME='? <name> [\s+ 'ESCAPE=' <escape> ]? };
-    token name       { $<val>=\w+ | <lctrls> | [<.qq> $<val>=[ <[ 0..9 '/._' \- \\ ] +alpha>* ] <.qq>] };
+    token name       { $<val>=\w+ | <lctrls> | [<.qq> $<val>=[ <[ 0..9 /._ \- \\ ] +alpha>* ] <.qq>] };
     regex qq         { '"' };
     token lctrls     { <lc_last> | <lc_first> };
     regex lc_last    { '!LAST' };


### PR DESCRIPTION
Quotes are not metacharacters in character classes and thus are no longer
necessary in the 'name' token.

The tests still pass, thus I'm pretty sure everything is working how it should. Unfortunately, my irc bouncer isn't working atm, and I can't ask you directly... :-/  If you have any comments about this PR, please don't hesitate.